### PR TITLE
Update notarize.sh to create Applications shortcut in the dmg

### DIFF
--- a/notarize.sh
+++ b/notarize.sh
@@ -77,6 +77,10 @@ EOT
 
     pack_dmg)
 
+        cd $project
+        ln -s /Applications Applications
+        cd ..
+
         hdiutil create -fs 'HFS+' -format UDBZ -ov -volname "$project" -srcfolder "$project" "$project.dmg"
 
         echo "Next, run $0 $project sign_dmg"


### PR DESCRIPTION
Update the pack_dmg step to create an alias to Applications in the dmg. When the user opens the dmg, they will be able to easily drag the app into the Applications folder directly from the dmg window.